### PR TITLE
Don't ignore config values set to false

### DIFF
--- a/lib/twirp_rails.rb
+++ b/lib/twirp_rails.rb
@@ -32,7 +32,9 @@ module TwirpRails
 
       class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
         def #{symbol}
-          @#{symbol} ||= #{symbol}_default
+          return #{symbol}_default if @#{symbol}.nil?
+
+          @#{symbol}
         end
       RUBY
 


### PR DESCRIPTION
`||=` overwrites config values set to `false` assigning them the default `true` value